### PR TITLE
Fix stable version of torch

### DIFF
--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -25,12 +25,9 @@ ENV PATH="/opt/venv/bin:$PATH"
 RUN pip install --no-cache-dir \
     --disable-pip-version-check \
     --no-compile \
-    torch==2.8.0+cpu \
-    torchvision==0.23.0+cpu \
-    torchaudio==2.8.0+cpu \
-    --index-url https://download.pytorch.org/whl/cpu \
     -r requirements.txt
 
+    
 # Clean up unnecessary files
 RUN find /opt/venv -name "*.pyc" -delete && \
     find /opt/venv -name "__pycache__" -type d -exec rm -rf {} + && \

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,8 @@
+torch==2.8.0+cpu
+torchvision==0.23.0+cpu
+torchaudio==2.8.0+cpu
+extra-index-url=https://download.pytorch.org/whl/cpu
+
 # Core web framework
 fastapi==0.115.13
 uvicorn[standard]==0.37.0
@@ -9,7 +14,7 @@ alembic==1.12.1
 
 # Data validation
 pydantic==2.11.9
-datasette==0.66.1
+datasets==2.18.0
 
 # System monitoring
 psutil==7.1.0

--- a/requirements_prod.txt
+++ b/requirements_prod.txt
@@ -9,7 +9,7 @@ alembic==1.12.1
 
 # Data validation
 pydantic==2.11.9
-
+datasets==2.18.0
 # System monitoring
 psutil==7.1.0
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Shift CPU-only PyTorch deps from Dockerfile into requirements, add datasets, and remove datasette.
> 
> - **Dependencies**:
>   - Add `torch==2.8.0+cpu`, `torchvision==0.23.0+cpu`, `torchaudio==2.8.0+cpu` and set `extra-index-url=https://download.pytorch.org/whl/cpu` in `requirements.txt`.
>   - Add `datasets==2.18.0` to `requirements.txt` and `requirements_prod.txt`.
>   - Remove `datasette` from `requirements.txt`.
> - **Docker**:
>   - Remove inline install of CPU-only PyTorch in `deployment/Dockerfile` and rely on `requirements.txt`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 31d3797567b14dc359740309eeb3adc0957ade59. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->